### PR TITLE
Use flags to select mode

### DIFF
--- a/addons/Gizmo3DScript/gizmo3D.gd
+++ b/addons/Gizmo3DScript/gizmo3D.gd
@@ -670,7 +670,7 @@ func _update_transform_gizmo_view() -> void:
 		RenderingServer.instance_set_transform(_scale_gizmo_instance[i], axis_angle)
 		RenderingServer.instance_set_visible(_scale_gizmo_instance[i], mode & ToolMode.SCALE)
 		RenderingServer.instance_set_transform(_scale_plane_gizmo_instance[i], axis_angle)
-		RenderingServer.instance_set_visible(_scale_plane_gizmo_instance[i], mode & ToolMode.SCALE)
+		RenderingServer.instance_set_visible(_scale_plane_gizmo_instance[i], mode == ToolMode.SCALE)
 		RenderingServer.instance_set_transform(_axis_gizmo_instance[i], xform)
 	
 	var show := show_axes and editing


### PR DESCRIPTION
This uses flag to select mode, which allows to do f.eg. `mode = ToolMode.MOVE | ToolMode.SCALE`, or using Godot editor: 
![image](https://github.com/user-attachments/assets/997a81a1-8402-464e-a64e-e90078957222)

It gives more granularity, as in my case I need to allow `MOVE` and `ROTATE` but not `SCALE`.

(This PR does not update Gizmo3DSharp).
((Thanks for this great plugin by the way)).